### PR TITLE
fix: create_standardized_filename now checks to ensure description matches entire file description when auto-numbering

### DIFF
--- a/R/S06-create_standardized_filename.R
+++ b/R/S06-create_standardized_filename.R
@@ -92,7 +92,7 @@ create_standardized_filename <- function( description,
       all_files != 'Placeholder.txt' # Exclude placeholder file
 
     matching_description <-
-      stringr::str_detect( all_files, stringr::fixed( description ) ) &
+      stringr::str_detect( all_files, stringr::fixed( paste0('-', description, '-')) ) &
       stringr::str_detect( all_files, stringr::fixed( '.' ) ) & # Exclude folders
       all_files != 'Placeholder.txt' # Exclude placeholder file
 


### PR DESCRIPTION

Resolves #1