### PR TITLE
Examples for create_standardized_filename did not pass R CMD CHECK

### DIFF
--- a/R/S06-create_standardized_filename.R
+++ b/R/S06-create_standardized_filename.R
@@ -26,11 +26,11 @@
 #' # Word document
 #' print( create_standardized_filename(
 #'   'Results', 'docx', project_version = 'v.1.0.0'
-#' )
+#' ))
 #' # Image file
 #' print( create_standardized_filename(
 #'   'Figure', 'png', project_version = 'v.1.0.0'
-#' )
+#' ))
 #'
 #' @export
 

--- a/man/create_standardized_filename.Rd
+++ b/man/create_standardized_filename.Rd
@@ -45,11 +45,11 @@ extension.
 # Word document
 print( create_standardized_filename(
   'Results', 'docx', project_version = 'v.1.0.0'
-)
+))
 # Image file
 print( create_standardized_filename(
   'Figure', 'png', project_version = 'v.1.0.0'
-)
+))
 
 }
 \author{


### PR DESCRIPTION
The examples in create_standardized_filename did not pass R CMD CHECK because they were missing closing parentheses for the `print` function. These have been added!