### PR TITLE
file_present: Checking Standardized File Names

### DIFF
--- a/R/S04-file_present.R
+++ b/R/S04-file_present.R
@@ -1,6 +1,8 @@
 #' Checks if a File is Present in a Folder
 #'
 #' Checks if a file is present in the current working directory.
+#' Can check either regular file or file using MGH-CAM's standardized
+#' file naming template: TXX-Description-MM_DD_YYYY-vX.X.X.ext
 #'
 #' @param string A file name or part of a file name to search for.
 #' @param output Character string indicating the type of output to
@@ -11,6 +13,9 @@
 #'   \item 'Index' or 'index'
 #'   \item 'Name' or 'name'
 #' }
+#' @param std_name A logical indicating whether the file follows the
+#'   standardized naming convention. If true, just matches the tag
+#'   and description of the file.
 #'
 #' @return Either...
 #' \enumerate{
@@ -25,15 +30,22 @@
 #' @export
 
 file_present <- function( string,
-                          output = 'Logical' ) {
+                          output = 'Logical',
+                          std_name = FALSE) {
 
   # All files and folders present
   # in working directory
   all_files <- dir()
 
-  # Determine if file name is present
+  # Determine if (standard) file name is present
   # in list of files/folders
-  check <- grepl( string, all_files, fixed = T )
+  if (std_name) {
+    fmatch <- regexpr('^\\w\\d{2}-[^-]*', all_files, perl = T)
+    tag_and_desc <- regmatches(all_files, fmatch)
+    check <- grepl(tag_and_desc, all_files, fixed = T)
+  } else{
+    check <- grepl( string, all_files, fixed = T )
+  }
 
   # Output
   if ( output %in% c( 'Logical', 'logical' ) ) {

--- a/R/S04-file_present.R
+++ b/R/S04-file_present.R
@@ -40,8 +40,8 @@ file_present <- function( string,
   # Determine if (standard) file name is present
   # in list of files/folders
   if (std_name) {
-    fmatch <- regexpr('^\\w\\d{2}-[^-]*', all_files, perl = T)
-    tag_and_desc <- regmatches(all_files, fmatch)
+    fmatch <- regexpr('^\\w\\d{2}-[^-]*', string, perl = T)
+    tag_and_desc <- regmatches(string, fmatch)
     check <- grepl(tag_and_desc, all_files, fixed = T)
   } else{
     check <- grepl( string, all_files, fixed = T )


### PR DESCRIPTION
The current version of the `file_present` function requires knowing the entire file name if one wishes to check if a previous version of a file (i.e. named with the standardized file format, `TXX-Description-MM_DD_YYYY-vX.X.X.ext`) exists in the current working directory.

One could, in theory, do a partial match, but this breaks down if files with the same description, but different extensions, exist in the working directory.

The `file_present` function has been updated to include a new argument: `std_name` that, if true, matches the tag and description of the `string` argument to files in the working directory. This should offer a more robust approach for determining whether an (old version of a) file exists in the working directory.

Next steps:
- Update calls to `file_present` throughout the package to take advantage of this feature (as there are several other functions where this computation is performed).