### PR TITLE
perf: Refactored redcap_read to use future to allow for parallelization.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,11 @@ Imports:
     tidyr,
     rlang,
     magrittr,
-    httr
+    httr,
+    purrr,
+    furrr,
+    progressr,
+    progress
 License: License: MIT + License
 Encoding: UTF-8
 LazyData: true

--- a/man/redcap_read.Rd
+++ b/man/redcap_read.Rd
@@ -32,7 +32,10 @@ A list which contains the following elements:
 This function seeks to mimic the \code{\link[REDCapR:redcap_read]{REDCapR::redcap_read()}} function,
 but with a more robust output that can handle bizarre characters
 and calculated fields. This function handles all REST API calls
-using httr.
+using httr. This function also uses calls to \link{furrr} and \link{future} for
+downloading batches from REDCap. The \link[future:plan]{plan} is not specified.
+Instead, the user should use the plan that works best for their
+specific use.
 }
 \author{
 William Schmitt


### PR DESCRIPTION
The commit in this pull request introduces some changes to `redcap_read()`:
- The code now relies on purrr, furrr, future, and progressr.
- The calls to download the REDCap database in batches is now done using `future_map` to allow the end-user to compute in parallel with `future::plan()`.
- progressr is used to temporarily display a progress bar to show download progress.
- Documentation is updated to reflect these additions.